### PR TITLE
Fix for DP-14 (Unused data providers are not removed)

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -33,10 +33,10 @@ class DispatchProvider extends React.Component {
   }
 }
 
-export const newTestApp = () => {
+export const newTestApp = (initialState = {}) => {
   const store = createStore((state, action) => (
     typeof action.reducer === 'function' ? action.reducer(state, action) : state
-  ), {content: ''})
+  ), {content: '', ...initialState})
 
   return {
     app: ({children}) => (


### PR DESCRIPTION
The test may look a bit confusing / complicated - the idea there is that I need a component with DP and refetch, which I need to mount at the beginning, then unmount and mount again and try refetch afterwards. This didn't work before the fix.

EDIT: this was already fixed in `keep_alive` so only this test is left in this PR...