### PR TITLE
Force fetch() when updateUser() changes getData

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -22,9 +22,11 @@ export default class DataProvider {
 
   updateUser(userId, {polling=Infinity, needed=true, rawGetData, getData}) {
     let needFetch = false
+    let forceFetch = false
 
     if (rawGetData != null && !lo.isEqual(rawGetData, this.rawGetData)) {
       needFetch = true
+      forceFetch = true
       this.rawGetData = rawGetData
       this.getData = getData
       this.loaded = false
@@ -42,7 +44,7 @@ export default class DataProvider {
     }
 
     if (needFetch) {
-      this.fetch()
+      this.fetch(forceFetch)
     }
   }
 
@@ -68,7 +70,7 @@ export default class DataProvider {
     }
 
     this.timer = setTimeout(() => {
-      this.fetch()
+      this.fetch(false)
     }, this.polling())
   }
 


### PR DESCRIPTION
This issue fixes missing `force` parameter of `fetch()` method, including a case when `updateUser()` changes existing `getData()` of current DataProvider.