### PR TITLE
DP-12 Take dispatch from store

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -2,32 +2,15 @@ import 'babel-polyfill'
 import ReactDOM from 'react-dom'
 import React from 'react'
 import './index.css'
-import PropTypes from 'prop-types'
 import {Provider} from 'react-redux'
 import configureStore from './configureStore'
 import {App} from './App'
 
 const store = configureStore()
 
-// ComponentWithDataProviders requires dispatch in context
-class DispatchProvider extends React.Component {
-    static childContextTypes = {
-      dispatch: PropTypes.func,
-    }
-
-    getChildContext() {
-      return {dispatch: this.props.dispatch}
-    }
-
-    render() {
-      return (<div> {this.props.children} </div>)
-    }
-}
-
 ReactDOM.render(
   <Provider store={store}>
-    <DispatchProvider dispatch={store.dispatch}>
-      <App />
-    </DispatchProvider>
+    <App />
   </Provider>,
-  document.getElementById('root'))
+  document.getElementById('root')
+)

--- a/src/util.js
+++ b/src/util.js
@@ -22,3 +22,6 @@ export function call(list) {
 }
 
 export const defaultOnAbort = [() => () => undefined]
+export function emptyDispatch() {
+  // do nothing
+}

--- a/src/withDataProviders.js
+++ b/src/withDataProviders.js
@@ -1,13 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import lo from 'lodash'
-<<<<<<< HEAD
-import { assert, call, IdGenerator, defaultOnAbort } from './util'
+import { assert, call, IdGenerator, defaultOnAbort, emptyDispatch } from './util'
 import { cfg } from './config'
-=======
-import {assert, call, IdGenerator, emptyDispatch} from './util'
-import {cfg} from './config'
->>>>>>> 06e35f8... Make store in context optional
 import {
   addDataProvider, addUserConfig, findDpWithRef, getAllUserConfigs, getDataProvider, getDPsForUser,
   refetch, removeDpUser
@@ -43,7 +38,7 @@ export function withDataProviders(getConfig) {
       }
 
       getDispatch() {
-        return this.context.store && this.context.store.dispatch || emptyDispatch
+        return this.context.store && this.context.store.dispatch || undefined
       }
 
       componentWillMount() {

--- a/src/withDataProviders.js
+++ b/src/withDataProviders.js
@@ -1,8 +1,13 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import lo from 'lodash'
+<<<<<<< HEAD
 import { assert, call, IdGenerator, defaultOnAbort } from './util'
 import { cfg } from './config'
+=======
+import {assert, call, IdGenerator, emptyDispatch} from './util'
+import {cfg} from './config'
+>>>>>>> 06e35f8... Make store in context optional
 import {
   addDataProvider, addUserConfig, findDpWithRef, getAllUserConfigs, getDataProvider, getDPsForUser,
   refetch, removeDpUser
@@ -34,7 +39,11 @@ export function withDataProviders(getConfig) {
     return class ComponentWithDataProviders extends React.Component {
 
       static contextTypes = {
-        store: PropTypes.object.isRequired,
+        store: PropTypes.object,
+      }
+
+      getDispatch() {
+        return this.context.store && this.context.store.dispatch || emptyDispatch
       }
 
       componentWillMount() {
@@ -96,9 +105,9 @@ export function withDataProviders(getConfig) {
               rawGetData,
               getData: () => call(rawGetData),
               rawOnData,
-              onData: (data) => call(rawOnData)(ref, data, this.context.store.dispatch),
+              onData: (data) => call(rawOnData)(ref, data, this.getDispatch()),
               rawOnAbort,
-              onAbort: (errorData) => call(rawOnAbort)(ref, errorData, this.context.store.dispatch),
+              onAbort: (errorData) => call(rawOnAbort)(ref, errorData, this.getDispatch()),
               initialData,
               responseHandler,
               keepAliveFor

--- a/src/withDataProviders.js
+++ b/src/withDataProviders.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import lo from 'lodash'
-import {assert, call, IdGenerator, defaultOnAbort} from './util'
-import {cfg} from './config'
+import { assert, call, IdGenerator, defaultOnAbort } from './util'
+import { cfg } from './config'
 import {
   addDataProvider, addUserConfig, findDpWithRef, getAllUserConfigs, getDataProvider, getDPsForUser,
   refetch, removeDpUser
@@ -34,7 +34,7 @@ export function withDataProviders(getConfig) {
     return class ComponentWithDataProviders extends React.Component {
 
       static contextTypes = {
-        dispatch: PropTypes.func.isRequired,
+        store: PropTypes.object.isRequired,
       }
 
       componentWillMount() {
@@ -51,7 +51,7 @@ export function withDataProviders(getConfig) {
       }
 
       componentWillUnmount() {
-        for (let {id: dpId} of getDPsForUser(this.id)) {
+        for (let { id: dpId } of getDPsForUser(this.id)) {
           removeDpUser(dpId, this.id)
         }
       }
@@ -96,9 +96,9 @@ export function withDataProviders(getConfig) {
               rawGetData,
               getData: () => call(rawGetData),
               rawOnData,
-              onData: (data) => call(rawOnData)(ref, data, this.context.dispatch),
+              onData: (data) => call(rawOnData)(ref, data, this.context.store.dispatch),
               rawOnAbort,
-              onAbort: (errorData) => call(rawOnAbort)(ref, errorData, this.context.dispatch),
+              onAbort: (errorData) => call(rawOnAbort)(ref, errorData, this.context.store.dispatch),
               initialData,
               responseHandler,
               keepAliveFor
@@ -139,7 +139,7 @@ export function withDataProviders(getConfig) {
 
         // this is used when handleUpdate is called for existing component, but with new props,
         // so its data providers could've changed
-        for (let {id: dpId} of oldDataProviders) {
+        for (let { id: dpId } of oldDataProviders) {
           if (!lo.has(newDataProviders, dpId)) {
             removeDpUser(dpId, this.id)
           }
@@ -147,13 +147,13 @@ export function withDataProviders(getConfig) {
       }
 
       render() {
-        const {show, error, fetching} = lo.entries(getAllUserConfigs(this.id)).reduce(({show, error, fetching},
-          [dpId, {needed, injectLoading}]) => ({
-          show: show && (!needed || getDataProvider(dpId).loaded),
-          error: error || (needed && getDataProvider(dpId).error),
-          fetching: fetching || (!needed && !getDataProvider(dpId).loaded && injectLoading),
-        }), {show: true, error: false, fetching: false})
-        const injectedProps = fetching ? {dataProviderLoading: fetching} : {}
+        const { show, error, fetching } = lo.entries(getAllUserConfigs(this.id)).reduce(({ show, error, fetching },
+          [dpId, { needed, injectLoading }]) => ({
+            show: show && (!needed || getDataProvider(dpId).loaded),
+            error: error || (needed && getDataProvider(dpId).error),
+            fetching: fetching || (!needed && !getDataProvider(dpId).loaded && injectLoading),
+          }), { show: true, error: false, fetching: false })
+        const injectedProps = fetching ? { dataProviderLoading: fetching } : {}
         return error
           ? this.errorComponent
           : show

--- a/test/common.js
+++ b/test/common.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import {createStore} from 'redux'
 import {Provider} from 'react-redux'
-import PropTypes from 'prop-types'
 import {Promise} from 'bluebird'
 
 export const GET_DATA_DELAY = 0.1 * 1000
@@ -19,20 +18,6 @@ export function getDataWithCount({data}, msDelay) {
 }
 getDataWithCount.counter = 0
 
-class DispatchProvider extends React.Component {
-  static childContextTypes = {
-    dispatch: PropTypes.func,
-  }
-
-  getChildContext() {
-    return {dispatch: this.props.dispatch}
-  }
-
-  render() {
-    return (<div>{this.props.children}</div>)
-  }
-}
-
 export const newTestApp = (initialState = {}) => {
   const store = createStore((state, action) => (
     typeof action.reducer === 'function' ? action.reducer(state, action) : state
@@ -41,9 +26,7 @@ export const newTestApp = (initialState = {}) => {
   return {
     app: ({children}) => (
       <Provider store={store}>
-        <DispatchProvider dispatch={store.dispatch}>
-          {children}
-        </DispatchProvider>
+        {children}
       </Provider>
     ),
     store


### PR DESCRIPTION
Currently, the DP looks for dispatch in the context, and if it's there it provides it into the onData function. However, react-redux doesn't provide dispatch, rather the whole store .

Check if there's the store in context, and provide its dispatch. We can create such dependency on Redux until we find some better solution. Most of our project are React-Redux anyways.
