### PR TITLE
Update README and rename LoadingIcon component

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The contract:
 * You can count on the data being fetched and handled when writing the code for
   the decorated React component
 
-# Example
+#### Example
 
-```
+```js
 class BlogPost extends React.Component {
   render() {
     let {title, body} = this.props
@@ -57,11 +57,40 @@ compose(
       keepAliveFor: 10 * 60 * 1000,
       // Optionally, the (first) fetch can be skipped by providing initialData (for
       // example, data can be put to html-data-attribute during server-side rendering)
-      initialData: {title: ..., body: ...}
+      initialData: {title: ..., body: ...},
+      // Optionally, override the default responseHandler behavior,
+      // see Global Configuration section for details
+      responseHandler: ...,
+      // Optionally, override the default loading component by defining your own, or 
+      // set it null to disable
+      loadingComponent: <MyLoadingComponent />
     },
     // more data providers...
   ]),
   connect((state, props) => state.blogData[props.blogPostId]))
 )(BlogPost)
 
+```
+
+### Global Configuration
+
+You can override some default settings and behavior by calling the `dataProvidersConfig({...})` function.
+
+Optional overridable settings:
+ * `responseHandler` - function that accepts `response` from user defined `getData()` function and processes it.
+ Default implementation expects a `Response` object (but simply returns `response` otherwise), and tries to parse
+ the body as JSON object.
+ * `loadingComponent` - component to display when DataProvider is fetching data
+ * `fetchTimeout` - time in milliseconds after which a new fetch (user supplied `getData`) is called. Default is 30s
+ * `maxTimeoutRetries` - max number of retries of the `getData` call after timeout. Default is 5
+ 
+#### Example
+
+```js
+dataProvidersConfig({
+  responseHandler: (response) => response,
+  loadingComponent: <MyLoadingComponent />,
+  fetchTimeout: 60 * 1000,
+  maxTimeoutRetries: 1
+})
 ```

--- a/src/LoadingComponent.js
+++ b/src/LoadingComponent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const LoadingIcon = ({color = '#777'}) => (
+export const LoadingComponent = ({color = '#777'}) => (
   <div className="loader" title="1">
     <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink"
       x="0px" y="0px" width="40px" height="40px" viewBox="0 0 50 50" xmlSpace="preserve"

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import {LoadingIcon} from './LoadingIcon'
+import {LoadingComponent} from './LoadingComponent'
 import {ABORT} from './DataProvider'
 
 export const cfg = {
   responseHandler: defaultResponseHandler,
-  loadingIcon: <LoadingIcon />,
+  loadingComponent: <LoadingComponent />,
   fetchTimeout: 30 * 1000,
   maxTimeoutRetries: 5
 }

--- a/src/withDataProviders.js
+++ b/src/withDataProviders.js
@@ -39,7 +39,7 @@ export function withDataProviders(getConfig) {
 
       componentWillMount() {
         this.id = idg.next()
-        this.loadingIcon = cfg.loadingIcon
+        this.loadingComponent = cfg.loadingComponent
         this.handleUpdate(this.props)
       }
 
@@ -67,14 +67,14 @@ export function withDataProviders(getConfig) {
             initialData,
             polling,
             needed,
-            loadingIcon,
+            loadingComponent,
             responseHandler = cfg.responseHandler,
             keepAliveFor = 0
           } = dpConfig
           assert(Number.isInteger(keepAliveFor) && keepAliveFor >= 0,
             'Parameter keepAliveFor must be a positive Integer or 0')
 
-          this.loadingIcon = loadingIcon === undefined ? this.loadingIcon : loadingIcon
+          this.loadingComponent = loadingComponent === undefined ? this.loadingComponent : loadingComponent
 
           let dpId = findDpWithRef(ref)
 
@@ -136,7 +136,7 @@ export function withDataProviders(getConfig) {
         let show = lo.entries(getAllUserConfigs(this.id)).every(([dpId, {needed}]) => {
           return !needed || getDataProvider(dpId).loaded
         })
-        return show ? <Component {...this.props} /> : this.loadingIcon
+        return show ? <Component {...this.props} /> : this.loadingComponent
       }
     }
   }


### PR DESCRIPTION
Update README with the added features.
Rename confusing name `LoadingIcon` to a clearer `LoadingComponent`.