### PR TITLE
Inject loading prop

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -67,11 +67,12 @@ export function addDataProvider(config) {
 }
 
 // adds new config for given userId - dpId
-export function addUserConfig(userId, dpId, {needed = true, polling = Infinity, refreshFn}) {
+export function addUserConfig(userId, dpId, {needed = true, polling = Infinity, injectLoading = false,
+  refreshFn}) {
   const oldPolling = getPolling(dpId)
   const isFirst = lo.isEmpty(getUsersForDp(dpId)) && !dataProviders[dpId].suspended()
 
-  lo.set(userConfigs, [userId, dpId], {needed, polling, refreshFn})
+  lo.set(userConfigs, [userId, dpId], {needed, polling, injectLoading, refreshFn})
   if (keepAliveDp(dpId)) {
     keepAlivePollingMap[dpId] = Math.min(polling, keepAlivePolling(dpId))
   }

--- a/src/withDataProviders.js
+++ b/src/withDataProviders.js
@@ -69,6 +69,7 @@ export function withDataProviders(getConfig) {
             initialData,
             polling,
             needed,
+            injectLoading,
             loadingComponent,
             errorComponent,
             responseHandler = cfg.responseHandler,
@@ -130,6 +131,7 @@ export function withDataProviders(getConfig) {
           addUserConfig(this.id, dpId, {
             needed,
             polling,
+            injectLoading,
             refreshFn: this.forceUpdate.bind(this)
           })
           newDataProviders[dpId] = dp.ref
@@ -145,14 +147,17 @@ export function withDataProviders(getConfig) {
       }
 
       render() {
-        const {show, error} = lo.entries(getAllUserConfigs(this.id)).reduce(({show, error}, [dpId, {needed}]) => ({
+        const {show, error, fetching} = lo.entries(getAllUserConfigs(this.id)).reduce(({show, error, fetching},
+          [dpId, {needed, injectLoading}]) => ({
           show: show && (!needed || getDataProvider(dpId).loaded),
-          error: error || (needed && getDataProvider(dpId).error)
-        }), {show: true, error: false})
+          error: error || (needed && getDataProvider(dpId).error),
+          fetching: fetching || (!needed && !getDataProvider(dpId).loaded && injectLoading),
+        }), {show: true, error: false, fetching: false})
+        const injectedProps = fetching ? {dataProviderLoading: fetching} : {}
         return error
           ? this.errorComponent
           : show
-            ? <Component {...this.props} />
+            ? <Component {...this.props} {...injectedProps} />
             : this.loadingComponent
       }
     }

--- a/test/withDataProviders.test.js
+++ b/test/withDataProviders.test.js
@@ -143,6 +143,27 @@ test('withDataProviders polling', async () => {
   expect(secondCount).toBe(firstCount + 1)
 })
 
+test('withDataProviders should show loading when (injectLoading=true) and (needed=false)', () => {
+  const {root} = renderMessageContainerApp({needed: false, injectLoading: true})
+
+  let renderedMessage = root.querySelector('div.message span.loading')
+  expect(renderedMessage).not.toBeNull()
+})
+
+test('withDataProviders should not show loading when injectLoading is not set', () => {
+  const {root} = renderMessageContainerApp({needed: false})
+
+  let renderedMessage = root.querySelector('div.message span.loading')
+  expect(renderedMessage).toBeNull()
+})
+
+test('withDataProviders should not show loading when injectLoading is set but (needed=true)', () => {
+  const {root} = renderMessageContainerApp({needed: true, injectLoading: true})
+
+  let renderedMessage = root.querySelector('div.message span.loading')
+  expect(renderedMessage).toBeNull()
+})
+
 test('DataProvider aborts after receiving ABORT from responseHandler', async () => {
   let failCount = 0
   dataProvidersConfig({responseHandler: (response) => (failCount++ < 1 ? ABORT : response)})
@@ -358,10 +379,11 @@ function messageProvider(dpSettings) {
   }
 }
 
-function Message({content}) {
+function Message({content, dataProviderLoading}) {
   return (
     <div className="message">
       <p>{content}</p>
+      {dataProviderLoading && <span className="loading" />}
     </div>
   )
 }


### PR DESCRIPTION
* Some components are aimed to be rendered even when data are not already
      loaded (needed === false), however one may want to also show
      custom loading based on some `loading` prop
* This allows to inject `dataProviderLoading` prop for those providers that have `injectLoading` set to `true` and `needed` set to `false`
* This does not distinguish which data are not loaded in case of multiple data providers
